### PR TITLE
ALSA: use plug:default instead of plughw:0,0

### DIFF
--- a/audiocfg
+++ b/audiocfg
@@ -1,6 +1,6 @@
 #320*16
-plughw:0,0
-plughw:0,0
+plug:default
+plug:default
 default
 Capture
 PCM

--- a/libdesktop/audio_alsa.c
+++ b/libdesktop/audio_alsa.c
@@ -36,8 +36,8 @@
 #define DEFBUFSIZE 6400
 #define DEFPERIODS 4
 
-#define DEF_devAudioInput "plughw:0,0"
-#define DEF_devAudioOutput "plughw:0,0"
+#define DEF_devAudioInput "plug:default"
+#define DEF_devAudioOutput "plug:default"
 #define DEF_devAudioControl "default"
 #define DEF_capture_mixer_elem "Capture"
 #define DEF_playback_mixer_elem "PCM"


### PR DESCRIPTION
Don't acquire hardware card, so PulseAudio and dmix may be employed to use other ALSA applications concurrently

Source: http://www.alsa-project.org/main/index.php/DeviceNames
